### PR TITLE
Use rustc_attrs to get good diagnostics.

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -262,7 +262,7 @@ impl Formatter {
 
     fn check_stack(&mut self, mut depth: usize) {
         while let Some(&index) = self.scan_stack.back() {
-            let mut entry = &mut self.buf[index];
+            let entry = &mut self.buf[index];
             match entry.token {
                 Token::Begin(_) => {
                     if depth == 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![warn(missing_docs)]
+#![feature(rustc_attrs)]
 
 // From rust-lang/rust/library
 pub mod builders;
@@ -168,6 +169,7 @@ pub use debug3_derive::Debug;
 /// }"
 /// );
 /// ```
+#[rustc_trivial_field_reads]
 pub trait Debug {
     /// Formats the value using the given formatter.
     ///

--- a/tests/it/algo.rs
+++ b/tests/it/algo.rs
@@ -3,6 +3,7 @@ use debug3::{pprint, Debug, Formatter};
 #[test]
 fn works() {
     #[derive(Debug)]
+    #[allow(dead_code)]
     struct Basic {
         a: String,
         b: i32,
@@ -736,6 +737,7 @@ fn big_map() {
 #[test]
 fn enum_many_ways() {
     #[derive(Debug)]
+    #[allow(dead_code)]
     enum Foo {
         A(i32),
         B(i32, &'static str),

--- a/tests/it/std.rs
+++ b/tests/it/std.rs
@@ -51,6 +51,7 @@ fn mutex() {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct Ref<'a, T: ?Sized> {
     ptr: &'a T,
 }

--- a/tests/it/ui/debug_not_field.stderr
+++ b/tests/it/ui/debug_not_field.stderr
@@ -14,5 +14,5 @@ error[E0277]: the trait bound `NoDebug: debug3::Debug` is not satisfied
             (T11,)
             (T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)
           and $N others
-  = note: required for the cast from `NoDebug` to the object type `dyn debug3::Debug`
+  = note: required for the cast from `&NoDebug` to `&dyn debug3::Debug`
   = note: this error originates in the derive macro `debug3::Debug` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/it/ui/unused_fields.rs
+++ b/tests/it/ui/unused_fields.rs
@@ -1,7 +1,6 @@
 #![deny(dead_code)] // Becuase ui-test requires an error, not warning
 
-// TODO: Add #[derive(debug3::Debug)], and have the same error.
-// https://twitter.com/adotinthevoid/status/1647682561366188034
+#[derive(debug3::Debug)]
 pub struct Foo {
     x: i32,
     y: i32,

--- a/tests/it/ui/unused_fields.stderr
+++ b/tests/it/ui/unused_fields.stderr
@@ -1,12 +1,13 @@
 error: field `y` is never read
- --> tests/it/ui/unused_fields.rs:7:5
+ --> tests/it/ui/unused_fields.rs:6:5
   |
-5 | pub struct Foo {
+4 | pub struct Foo {
   |            --- field in this struct
-6 |     x: i32,
-7 |     y: i32,
+5 |     x: i32,
+6 |     y: i32,
   |     ^
   |
+  = note: `Foo` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
 note: the lint level is defined here
  --> tests/it/ui/unused_fields.rs:1:9
   |


### PR DESCRIPTION
Can't be merged, but good to know how this works.

Hopefully T-Lang will one day stabilize this